### PR TITLE
Feature/fiscal year helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ So far, the quarter methods have been assuming a calendar year for the quarter d
 Quarter::first()->toFiscal();
 ```
 
+Please note that when using the `toFiscal` method, the resulting object assumes that the _current year_ is the start of the fiscal year. That is, if the current year is 2022, but you are in the fiscal year FY21 (which starts on July 1, 2021, and ends on June 30, 2022), the `Quarter::first()->toFiscal()` will return a date of `July 1, 2022` instead of `July 1, 2021`, because it assumes the current year is the start of the fiscal year.
+
+To avoid this behavior, you can use the helper method `getCurrentFiscalYear()` or `currentFiscalYear()` and pass that into the `year()` method like so: 
+
+```php
+// example, say today's date is May 1, 2022.
+// this means that we are in Q2 of the calendar year 2022
+// but in Q4 of Fiscal Year 2021
+// to get the first quarter of the current fiscal year, you can do this:
+
+//July 1, 2021 - September 30, 2021
+Quarter::first()->year(Quarter::getCurrentFiscalYear())->toFiscal();
+```
+
 You can chain the `year()` and `toFiscal()` methods together:
 
 ```php

--- a/src/Quarter.php
+++ b/src/Quarter.php
@@ -68,11 +68,11 @@ class Quarter extends Period
     {
         $today = CarbonImmutable::today();
 
-        //given today's date, determine the current calendar quarter
-        //1st quarter = Jan, Feb, Mar
-        //2nd quarter = Apr, May, Jun
-        //3rd quarter = Jul, Aug, Sep
-        //4th quarter = Oct, Nov, Dec
+        // given today's date, determine the current calendar quarter
+        // 1st quarter = Jan, Feb, Mar
+        // 2nd quarter = Apr, May, Jun
+        // 3rd quarter = Jul, Aug, Sep
+        // 4th quarter = Oct, Nov, Dec
         return match ($today->month) {
             1, 2, 3 => self::first(),
             4, 5, 6 => self::second(),
@@ -122,11 +122,11 @@ class Quarter extends Period
     {
         $today = CarbonImmutable::today();
 
-        //given today's date, determine the current calendar quarter
-        //1st quarter = Jan, Feb, Mar
-        //2nd quarter = Apr, May, Jun
-        //3rd quarter = Jul, Aug, Sep
-        //4th quarter = Oct, Nov, Dec
+        // given today's date, determine the current calendar quarter
+        // 1st quarter = Jan, Feb, Mar
+        // 2nd quarter = Apr, May, Jun
+        // 3rd quarter = Jul, Aug, Sep
+        // 4th quarter = Oct, Nov, Dec
         return match ($today->month) {
             1, 2, 3 => self::first(),
             4, 5, 6 => self::second(),
@@ -142,7 +142,7 @@ class Quarter extends Period
      */
     public function year(int $year): self
     {
-        //given the year, we need to mutate $this to be the same year
+        // given the year, we need to mutate $this to be the same year
         $this->startDate = $this->startDate->setYear($year);
         $this->endDate = $this->endDate->setYear($year);
 

--- a/src/Quarter.php
+++ b/src/Quarter.php
@@ -21,14 +21,13 @@ class Quarter extends Period
     public function __construct(
         CarbonImmutable $startDate,
         CarbonImmutable $endDate,
-        ?string         $name = null,
-        bool            $isFiscal = false,
-    )
-    {
+        ?string $name = null,
+        bool $isFiscal = false,
+    ) {
         parent::__construct($startDate, $endDate);
         $this->isFiscal = $isFiscal;
 
-        if (!isset($name)) {
+        if (! isset($name)) {
             $month = $startDate->month;
 
             if ($this->isFiscal) {
@@ -53,6 +52,14 @@ class Quarter extends Period
         }
     }
 
+    public static function getCurrentFiscalYear(): int
+    {
+        $today = CarbonImmutable::today();
+
+        return $today->month >= 7
+            ? $today->year
+            : $today->year - 1;
+    }
 
     /**
      * @throws \Exception
@@ -60,6 +67,7 @@ class Quarter extends Period
     public static function current(): self
     {
         $today = CarbonImmutable::today();
+
         //given today's date, determine the current calendar quarter
         //1st quarter = Jan, Feb, Mar
         //2nd quarter = Apr, May, Jun
@@ -79,7 +87,7 @@ class Quarter extends Period
         return new Quarter(
             startDate: $startOfYear = CarbonImmutable::today()->startOfYear(),
             endDate: $startOfYear->addMonths(2)->endOfMonth(),
-            name: "Q1",
+            name: 'Q1',
         );
     }
 
@@ -88,7 +96,7 @@ class Quarter extends Period
         return new Quarter(
             startDate: $startOfYear = CarbonImmutable::today()->startOfYear()->addMonths(3),
             endDate: $startOfYear->addMonths(2)->endOfMonth(),
-            name: "Q2",
+            name: 'Q2',
         );
     }
 
@@ -97,7 +105,7 @@ class Quarter extends Period
         return new Quarter(
             startDate: $startOfYear = CarbonImmutable::today()->startOfYear()->addMonths(6),
             endDate: $startOfYear->addMonths(2)->endOfMonth(),
-            name: "Q3",
+            name: 'Q3',
         );
     }
 
@@ -106,13 +114,14 @@ class Quarter extends Period
         return new Quarter(
             startDate: $startOfYear = CarbonImmutable::today()->startOfYear()->addMonths(9),
             endDate: $startOfYear->addMonths(2)->endOfMonth(),
-            name: "Q4",
+            name: 'Q4',
         );
     }
 
     public static function currentCal(): self
     {
         $today = CarbonImmutable::today();
+
         //given today's date, determine the current calendar quarter
         //1st quarter = Jan, Feb, Mar
         //2nd quarter = Apr, May, Jun
@@ -128,7 +137,7 @@ class Quarter extends Period
     }
 
     /**
-     * @param int $year (format YYYY)
+     * @param  int  $year  (format YYYY)
      * @return $this
      */
     public function year(int $year): self
@@ -142,7 +151,8 @@ class Quarter extends Period
 
     public function next(): self
     {
-        $nextName = 'Q' . (($this->name === 'Q4') ? 1 : (int)substr($this->name, 1) + 1);
+        $nextName = 'Q'.(($this->name === 'Q4') ? 1 : (int) substr($this->name, 1) + 1);
+
         return new Quarter(
             startDate: $this->endDate->addDays()->setTime(0, 0, 0),
             endDate: $this->endDate->addDay()->addMonths(2)->endOfMonth(),
@@ -153,7 +163,8 @@ class Quarter extends Period
 
     public function previous(): self
     {
-        $prevName = 'Q' . (($this->name === 'Q1') ? 4 : (int)substr($this->name, 1) - 1);
+        $prevName = 'Q'.(($this->name === 'Q1') ? 4 : (int) substr($this->name, 1) - 1);
+
         return new Quarter(
             startDate: $this->startDate->subDay()->subMonths(2)->startOfMonth(),
             endDate: $this->startDate->subDay()->setTime(23, 59, 59, 999999),
@@ -179,7 +190,7 @@ class Quarter extends Period
     public function asFiscal(): self
     {
         $this->isFiscal = true;
-        $this->name = 'Q' . ((intval(substr($this->name, 1)) + 2 - 1) % 4 + 1);
+        $this->name = 'Q'.((intval(substr($this->name, 1)) + 2 - 1) % 4 + 1);
 
         return $this;
     }
@@ -204,8 +215,6 @@ class Quarter extends Period
 
     /**
      * Returns the name of the quarter in a format like "Q1 CY24" or "Q1 FY25".
-     *
-     * @return string
      */
     public function getName(): string
     {
@@ -214,11 +223,11 @@ class Quarter extends Period
         if ($this->isFiscal) {
             // Fiscal year logic: if the start date is on or after July 1, use the next calendar year
             $fiscalYear = $this->startDate->month >= 7 ? $year + 1 : $year;
-            return "{$this->name} FY" . substr($fiscalYear, -2);
+
+            return "{$this->name} FY".substr($fiscalYear, -2);
         } else {
             // Calendar year logic
-            return "{$this->name} CY" . substr($year, -2);
+            return "{$this->name} CY".substr($year, -2);
         }
     }
-
 }

--- a/tests/QuarterTest.php
+++ b/tests/QuarterTest.php
@@ -203,12 +203,12 @@ class QuarterTest extends TestCase
     {
         $today = CarbonImmutable::today();
 
-        //if $today is before July 1st of the current year, then the expected start date for
-        //the fiscal year is July 1st of the previous calendar year
-        if($today->isBefore(CarbonImmutable::parse(CarbonImmutable::today()->format('Y')) . '-07-01')) {
-            $expectedQ1StartDate =  CarbonImmutable::parse((CarbonImmutable::today()->format('Y') - 1) . '-07-01');
+        // if $today is before July 1st of the current year, then the expected start date for
+        // the fiscal year is July 1st of the previous calendar year
+        if ($today->isBefore(CarbonImmutable::parse(CarbonImmutable::today()->format('Y')).'-07-01')) {
+            $expectedQ1StartDate = CarbonImmutable::parse((CarbonImmutable::today()->format('Y') - 1).'-07-01');
         } else {
-            $expectedQ1StartDate =  CarbonImmutable::parse(CarbonImmutable::today()->format('Y') . '-07-01');
+            $expectedQ1StartDate = CarbonImmutable::parse(CarbonImmutable::today()->format('Y').'-07-01');
         }
 
         $FYQ1 = Quarter::first()->year(Quarter::getCurrentFiscalYear())->toFiscal();

--- a/tests/QuarterTest.php
+++ b/tests/QuarterTest.php
@@ -35,8 +35,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first();
 
-        $this->assertEquals($year . '-01-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-03-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-01-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-03-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_second_calendar_quarter(): void
@@ -45,8 +45,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::second();
 
-        $this->assertEquals($year . '-04-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-06-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-04-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-06-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_third_calendar_quarter(): void
@@ -55,8 +55,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::third();
 
-        $this->assertEquals($year . '-07-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-09-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-07-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-09-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_fourth_calendar_quarter(): void
@@ -65,8 +65,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::fourth();
 
-        $this->assertEquals($year . '-10-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-12-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-10-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-12-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_first_fiscal_quarter(): void
@@ -75,8 +75,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first()->toFiscal();
 
-        $this->assertEquals($year . '-07-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-09-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-07-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-09-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_second_fiscal_quarter(): void
@@ -85,8 +85,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::second()->toFiscal();
 
-        $this->assertEquals($year . '-10-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-12-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-10-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-12-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_third_fiscal_quarter(): void
@@ -95,8 +95,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::third()->toFiscal();
 
-        $this->assertEquals($year + 1 . '-01-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year + 1 . '-03-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year + 1 .'-01-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year + 1 .'-03-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_fourth_fiscal_quarter(): void
@@ -105,8 +105,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::fourth()->toFiscal();
 
-        $this->assertEquals($year + 1 . '-04-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year + 1 . '-06-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year + 1 .'-04-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year + 1 .'-06-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_get_next_quarter(): void
@@ -115,8 +115,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first()->next();
 
-        $this->assertEquals($year . '-04-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-06-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-04-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-06-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_get_previous_quarter(): void
@@ -125,8 +125,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first()->previous();
 
-        $this->assertEquals($year - 1 . '-10-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year - 1 . '-12-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year - 1 .'-10-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year - 1 .'-12-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_get_quarter_as_period_object(): void
@@ -135,8 +135,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first()->asPeriod();
 
-        $this->assertEquals($year . '-01-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-03-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-01-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-03-31', $firstQuarter->endDate->toDateString());
         $this->assertInstanceOf(Period::class, $firstQuarter);
     }
 
@@ -158,22 +158,22 @@ class QuarterTest extends TestCase
         $fourthFiscalQuarter = Quarter::fourth()->toFiscal();
 
         // Assertions for calendar year quarters
-        $this->assertEquals('Q1 CY' . substr($calendarYear, -2), $firstCalendarQuarter->getName());
-        $this->assertEquals('Q2 CY' . substr($calendarYear, -2), $secondCalendarQuarter->getName());
-        $this->assertEquals('Q3 CY' . substr($calendarYear, -2), $thirdCalendarQuarter->getName());
-        $this->assertEquals('Q4 CY' . substr($calendarYear, -2), $fourthCalendarQuarter->getName());
+        $this->assertEquals('Q1 CY'.substr($calendarYear, -2), $firstCalendarQuarter->getName());
+        $this->assertEquals('Q2 CY'.substr($calendarYear, -2), $secondCalendarQuarter->getName());
+        $this->assertEquals('Q3 CY'.substr($calendarYear, -2), $thirdCalendarQuarter->getName());
+        $this->assertEquals('Q4 CY'.substr($calendarYear, -2), $fourthCalendarQuarter->getName());
 
         // Assertions for fiscal year quarters
-        $this->assertEquals('Q1 FY' . substr($fiscalYear, -2), $firstFiscalQuarter->getName());
-        $this->assertEquals('Q2 FY' . substr($fiscalYear, -2), $secondFiscalQuarter->getName());
-        $this->assertEquals('Q3 FY' . substr($fiscalYear, -2), $thirdFiscalQuarter->getName());
-        $this->assertEquals('Q4 FY' . substr($fiscalYear, -2), $fourthFiscalQuarter->getName());
+        $this->assertEquals('Q1 FY'.substr($fiscalYear, -2), $firstFiscalQuarter->getName());
+        $this->assertEquals('Q2 FY'.substr($fiscalYear, -2), $secondFiscalQuarter->getName());
+        $this->assertEquals('Q3 FY'.substr($fiscalYear, -2), $thirdFiscalQuarter->getName());
+        $this->assertEquals('Q4 FY'.substr($fiscalYear, -2), $fourthFiscalQuarter->getName());
     }
 
     public function test_current_quarter_names(): void
     {
         $calendarYear = CarbonImmutable::today()->year;
-        $fiscalYear = $calendarYear + 1;
+        $fiscalYear = $calendarYear;
 
         // Calendar and fiscal quarters based on the current date
         $currentCalendarQuarter = Quarter::current();
@@ -181,17 +181,17 @@ class QuarterTest extends TestCase
 
         // Determine expected quarter names based on the current date
         $expectedCalendarQuarter = match (CarbonImmutable::today()->quarter) {
-            1 => 'Q1 CY' . substr($calendarYear, -2),
-            2 => 'Q2 CY' . substr($calendarYear, -2),
-            3 => 'Q3 CY' . substr($calendarYear, -2),
-            4 => 'Q4 CY' . substr($calendarYear, -2),
+            1 => 'Q1 CY'.substr($calendarYear, -2),
+            2 => 'Q2 CY'.substr($calendarYear, -2),
+            3 => 'Q3 CY'.substr($calendarYear, -2),
+            4 => 'Q4 CY'.substr($calendarYear, -2),
         };
 
         $expectedFiscalQuarter = match (CarbonImmutable::today()->quarter) {
-            1 => 'Q3 FY' . substr($fiscalYear, -2),
-            2 => 'Q4 FY' . substr($fiscalYear, -2),
-            3 => 'Q1 FY' . substr($fiscalYear, -2),
-            4 => 'Q2 FY' . substr($fiscalYear, -2),
+            1 => 'Q3 FY'.substr($fiscalYear, -2),
+            2 => 'Q4 FY'.substr($fiscalYear, -2),
+            3 => 'Q1 FY'.substr($fiscalYear, -2),
+            4 => 'Q2 FY'.substr($fiscalYear, -2),
         };
 
         // Assertions for current calendar and fiscal quarters
@@ -199,4 +199,20 @@ class QuarterTest extends TestCase
         $this->assertEquals($expectedFiscalQuarter, $currentFiscalQuarter->getName());
     }
 
+    public function test_fiscal_quarter_if_current_date_is_in_next_year(): void
+    {
+        $today = CarbonImmutable::today();
+
+        //if $today is before July 1st of the current year, then the expected start date for
+        //the fiscal year is July 1st of the previous calendar year
+        if($today->isBefore(CarbonImmutable::parse(CarbonImmutable::today()->format('Y')) . '-07-01')) {
+            $expectedQ1StartDate =  CarbonImmutable::parse((CarbonImmutable::today()->format('Y') - 1) . '-07-01');
+        } else {
+            $expectedQ1StartDate =  CarbonImmutable::parse(CarbonImmutable::today()->format('Y') . '-07-01');
+        }
+
+        $FYQ1 = Quarter::first()->year(Quarter::getCurrentFiscalYear())->toFiscal();
+
+        $this->assertEquals($FYQ1->startDate()->toDateString(), $expectedQ1StartDate->toDateString());
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,5 @@ class TestCase extends Orchestra
         ];
     }
 
-    public function getEnvironmentSetUp($app)
-    {
-    }
+    public function getEnvironmentSetUp($app) {}
 }


### PR DESCRIPTION
Added a helper function to determine the current fiscal year, because the `toFiscal()` method assumes that the fiscal year being worked with is equivalent to the current calendar year, which causes problems in Q3 and Q4 of a given fiscal year, since their year is the fiscal year + 1