### PR TITLE
Previous() Method Improvements

### DIFF
--- a/src/Quarter.php
+++ b/src/Quarter.php
@@ -21,14 +21,13 @@ class Quarter extends Period
     public function __construct(
         CarbonImmutable $startDate,
         CarbonImmutable $endDate,
-        ?string         $name = null,
-        bool            $isFiscal = false,
-    )
-    {
+        ?string $name = null,
+        bool $isFiscal = false,
+    ) {
         parent::__construct($startDate, $endDate);
         $this->isFiscal = $isFiscal;
 
-        if (!isset($name)) {
+        if (! isset($name)) {
             $month = $startDate->month;
 
             if ($this->isFiscal) {
@@ -138,7 +137,7 @@ class Quarter extends Period
     }
 
     /**
-     * @param int $year (format YYYY)
+     * @param  int  $year  (format YYYY)
      * @return $this
      */
     public function year(int $year): self
@@ -152,7 +151,7 @@ class Quarter extends Period
 
     public function next(): self
     {
-        $nextName = 'Q' . (($this->name === 'Q4') ? 1 : (int)substr($this->name, 1) + 1);
+        $nextName = 'Q'.(($this->name === 'Q4') ? 1 : (int) substr($this->name, 1) + 1);
 
         return new Quarter(
             startDate: $this->endDate->addDays()->setTime(0, 0, 0),
@@ -180,7 +179,7 @@ class Quarter extends Period
         return new self(
             startDate: $newStart,
             endDate: $newEnd,
-            name: 'Q' . $quarterNum,
+            name: 'Q'.$quarterNum,
             isFiscal: $this->isFiscal,
         );
     }
@@ -221,7 +220,7 @@ class Quarter extends Period
     public function asFiscal(): self
     {
         $this->isFiscal = true;
-        $this->name = 'Q' . ((intval(substr($this->name, 1)) + 2 - 1) % 4 + 1);
+        $this->name = 'Q'.((intval(substr($this->name, 1)) + 2 - 1) % 4 + 1);
 
         return $this;
     }
@@ -250,10 +249,10 @@ class Quarter extends Period
             // Fiscal year logic: if the start date is on or after July 1, use the current calendar year
             $fiscalYear = $this->startDate->month < 7 ? $year - 1 : $year;
 
-            return "{$this->name} FY" . substr($fiscalYear, -2);
+            return "{$this->name} FY".substr($fiscalYear, -2);
         } else {
             // Calendar year logic
-            return "{$this->name} CY" . substr($year, -2);
+            return "{$this->name} CY".substr($year, -2);
         }
     }
 }

--- a/tests/QuarterTest.php
+++ b/tests/QuarterTest.php
@@ -35,8 +35,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first();
 
-        $this->assertEquals($year . '-01-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-03-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-01-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-03-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_second_calendar_quarter(): void
@@ -45,8 +45,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::second();
 
-        $this->assertEquals($year . '-04-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-06-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-04-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-06-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_third_calendar_quarter(): void
@@ -55,8 +55,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::third();
 
-        $this->assertEquals($year . '-07-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-09-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-07-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-09-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_fourth_calendar_quarter(): void
@@ -65,8 +65,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::fourth();
 
-        $this->assertEquals($year . '-10-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-12-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-10-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-12-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_first_fiscal_quarter(): void
@@ -75,8 +75,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first()->toFiscal();
 
-        $this->assertEquals($fiscalYear . '-07-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($fiscalYear . '-09-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($fiscalYear.'-07-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($fiscalYear.'-09-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_second_fiscal_quarter(): void
@@ -85,8 +85,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::second()->toFiscal();
 
-        $this->assertEquals($fiscalYear . '-10-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($fiscalYear . '-12-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($fiscalYear.'-10-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($fiscalYear.'-12-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_third_fiscal_quarter(): void
@@ -95,8 +95,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::third()->toFiscal();
 
-        $this->assertEquals($fiscalYear + 1 . '-01-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($fiscalYear + 1 . '-03-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($fiscalYear + 1 .'-01-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($fiscalYear + 1 .'-03-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_fourth_fiscal_quarter(): void
@@ -105,8 +105,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::fourth()->toFiscal();
 
-        $this->assertEquals($fiscalYear + 1 . '-04-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($fiscalYear + 1 . '-06-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($fiscalYear + 1 .'-04-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($fiscalYear + 1 .'-06-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_get_next_quarter(): void
@@ -115,8 +115,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first()->next();
 
-        $this->assertEquals($year . '-04-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-06-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-04-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-06-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_get_previous_quarter(): void
@@ -125,20 +125,20 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first()->previous();
 
-        $this->assertEquals($year - 1 . '-10-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year - 1 . '-12-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year - 1 .'-10-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year - 1 .'-12-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_get_previous_n_quarter(): void
     {
-        {
-            $year = CarbonImmutable::today()->year;
 
-            $firstQuarter = Quarter::first()->previous(2);
+        $year = CarbonImmutable::today()->year;
 
-            $this->assertEquals($year - 1 . '-07-01', $firstQuarter->startDate->toDateString());
-            $this->assertEquals($year - 1 . '-09-30', $firstQuarter->endDate->toDateString());
-        }
+        $firstQuarter = Quarter::first()->previous(2);
+
+        $this->assertEquals($year - 1 .'-07-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year - 1 .'-09-30', $firstQuarter->endDate->toDateString());
+
     }
 
     public function test_get_quarter_as_period_object(): void
@@ -147,8 +147,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first()->asPeriod();
 
-        $this->assertEquals($year . '-01-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year . '-03-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year.'-01-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year.'-03-31', $firstQuarter->endDate->toDateString());
         $this->assertInstanceOf(Period::class, $firstQuarter);
     }
 
@@ -170,16 +170,16 @@ class QuarterTest extends TestCase
         $fourthFiscalQuarter = Quarter::fourth()->toFiscal();
 
         // Assertions for calendar year quarters
-        $this->assertEquals('Q1 CY' . substr($calendarYear, -2), $firstCalendarQuarter->getName());
-        $this->assertEquals('Q2 CY' . substr($calendarYear, -2), $secondCalendarQuarter->getName());
-        $this->assertEquals('Q3 CY' . substr($calendarYear, -2), $thirdCalendarQuarter->getName());
-        $this->assertEquals('Q4 CY' . substr($calendarYear, -2), $fourthCalendarQuarter->getName());
+        $this->assertEquals('Q1 CY'.substr($calendarYear, -2), $firstCalendarQuarter->getName());
+        $this->assertEquals('Q2 CY'.substr($calendarYear, -2), $secondCalendarQuarter->getName());
+        $this->assertEquals('Q3 CY'.substr($calendarYear, -2), $thirdCalendarQuarter->getName());
+        $this->assertEquals('Q4 CY'.substr($calendarYear, -2), $fourthCalendarQuarter->getName());
 
         // Assertions for fiscal year quarters
-        $this->assertEquals('Q1 FY' . substr($fiscalYear, -2), $firstFiscalQuarter->getName());
-        $this->assertEquals('Q2 FY' . substr($fiscalYear, -2), $secondFiscalQuarter->getName());
-        $this->assertEquals('Q3 FY' . substr($fiscalYear, -2), $thirdFiscalQuarter->getName());
-        $this->assertEquals('Q4 FY' . substr($fiscalYear, -2), $fourthFiscalQuarter->getName());
+        $this->assertEquals('Q1 FY'.substr($fiscalYear, -2), $firstFiscalQuarter->getName());
+        $this->assertEquals('Q2 FY'.substr($fiscalYear, -2), $secondFiscalQuarter->getName());
+        $this->assertEquals('Q3 FY'.substr($fiscalYear, -2), $thirdFiscalQuarter->getName());
+        $this->assertEquals('Q4 FY'.substr($fiscalYear, -2), $fourthFiscalQuarter->getName());
     }
 
     public function test_current_quarter_names(): void
@@ -193,17 +193,17 @@ class QuarterTest extends TestCase
 
         // Determine expected quarter names based on the current date
         $expectedCalendarQuarter = match (CarbonImmutable::today()->quarter) {
-            1 => 'Q1 CY' . substr($calendarYear, -2),
-            2 => 'Q2 CY' . substr($calendarYear, -2),
-            3 => 'Q3 CY' . substr($calendarYear, -2),
-            4 => 'Q4 CY' . substr($calendarYear, -2),
+            1 => 'Q1 CY'.substr($calendarYear, -2),
+            2 => 'Q2 CY'.substr($calendarYear, -2),
+            3 => 'Q3 CY'.substr($calendarYear, -2),
+            4 => 'Q4 CY'.substr($calendarYear, -2),
         };
 
         $expectedFiscalQuarter = match (CarbonImmutable::today()->quarter) {
-            1 => 'Q3 FY' . substr($fiscalYear - 1, -2),
-            2 => 'Q4 FY' . substr($fiscalYear - 1, -2),
-            3 => 'Q1 FY' . substr($fiscalYear - 1, -2),
-            4 => 'Q2 FY' . substr($fiscalYear - 1, -2),
+            1 => 'Q3 FY'.substr($fiscalYear - 1, -2),
+            2 => 'Q4 FY'.substr($fiscalYear - 1, -2),
+            3 => 'Q1 FY'.substr($fiscalYear - 1, -2),
+            4 => 'Q2 FY'.substr($fiscalYear - 1, -2),
         };
 
         // dd($expectedCalendarQuarter, $expectedFiscalQuarter);

--- a/tests/QuarterTest.php
+++ b/tests/QuarterTest.php
@@ -35,8 +35,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first();
 
-        $this->assertEquals($year.'-01-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year.'-03-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year . '-01-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year . '-03-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_second_calendar_quarter(): void
@@ -45,8 +45,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::second();
 
-        $this->assertEquals($year.'-04-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year.'-06-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year . '-04-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year . '-06-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_third_calendar_quarter(): void
@@ -55,8 +55,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::third();
 
-        $this->assertEquals($year.'-07-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year.'-09-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year . '-07-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year . '-09-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_fourth_calendar_quarter(): void
@@ -65,8 +65,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::fourth();
 
-        $this->assertEquals($year.'-10-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year.'-12-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year . '-10-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year . '-12-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_first_fiscal_quarter(): void
@@ -75,8 +75,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first()->toFiscal();
 
-        $this->assertEquals($fiscalYear.'-07-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($fiscalYear.'-09-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($fiscalYear . '-07-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($fiscalYear . '-09-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_second_fiscal_quarter(): void
@@ -85,8 +85,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::second()->toFiscal();
 
-        $this->assertEquals($fiscalYear.'-10-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($fiscalYear.'-12-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($fiscalYear . '-10-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($fiscalYear . '-12-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_third_fiscal_quarter(): void
@@ -95,8 +95,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::third()->toFiscal();
 
-        $this->assertEquals($fiscalYear + 1 .'-01-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($fiscalYear + 1 .'-03-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($fiscalYear + 1 . '-01-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($fiscalYear + 1 . '-03-31', $firstQuarter->endDate->toDateString());
     }
 
     public function test_fourth_fiscal_quarter(): void
@@ -105,8 +105,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::fourth()->toFiscal();
 
-        $this->assertEquals($fiscalYear + 1 .'-04-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($fiscalYear + 1 .'-06-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($fiscalYear + 1 . '-04-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($fiscalYear + 1 . '-06-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_get_next_quarter(): void
@@ -115,8 +115,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first()->next();
 
-        $this->assertEquals($year.'-04-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year.'-06-30', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year . '-04-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year . '-06-30', $firstQuarter->endDate->toDateString());
     }
 
     public function test_get_previous_quarter(): void
@@ -125,8 +125,20 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first()->previous();
 
-        $this->assertEquals($year - 1 .'-10-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year - 1 .'-12-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year - 1 . '-10-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year - 1 . '-12-31', $firstQuarter->endDate->toDateString());
+    }
+
+    public function test_get_previous_n_quarter(): void
+    {
+        {
+            $year = CarbonImmutable::today()->year;
+
+            $firstQuarter = Quarter::first()->previous(2);
+
+            $this->assertEquals($year - 1 . '-07-01', $firstQuarter->startDate->toDateString());
+            $this->assertEquals($year - 1 . '-09-30', $firstQuarter->endDate->toDateString());
+        }
     }
 
     public function test_get_quarter_as_period_object(): void
@@ -135,8 +147,8 @@ class QuarterTest extends TestCase
 
         $firstQuarter = Quarter::first()->asPeriod();
 
-        $this->assertEquals($year.'-01-01', $firstQuarter->startDate->toDateString());
-        $this->assertEquals($year.'-03-31', $firstQuarter->endDate->toDateString());
+        $this->assertEquals($year . '-01-01', $firstQuarter->startDate->toDateString());
+        $this->assertEquals($year . '-03-31', $firstQuarter->endDate->toDateString());
         $this->assertInstanceOf(Period::class, $firstQuarter);
     }
 
@@ -158,16 +170,16 @@ class QuarterTest extends TestCase
         $fourthFiscalQuarter = Quarter::fourth()->toFiscal();
 
         // Assertions for calendar year quarters
-        $this->assertEquals('Q1 CY'.substr($calendarYear, -2), $firstCalendarQuarter->getName());
-        $this->assertEquals('Q2 CY'.substr($calendarYear, -2), $secondCalendarQuarter->getName());
-        $this->assertEquals('Q3 CY'.substr($calendarYear, -2), $thirdCalendarQuarter->getName());
-        $this->assertEquals('Q4 CY'.substr($calendarYear, -2), $fourthCalendarQuarter->getName());
+        $this->assertEquals('Q1 CY' . substr($calendarYear, -2), $firstCalendarQuarter->getName());
+        $this->assertEquals('Q2 CY' . substr($calendarYear, -2), $secondCalendarQuarter->getName());
+        $this->assertEquals('Q3 CY' . substr($calendarYear, -2), $thirdCalendarQuarter->getName());
+        $this->assertEquals('Q4 CY' . substr($calendarYear, -2), $fourthCalendarQuarter->getName());
 
         // Assertions for fiscal year quarters
-        $this->assertEquals('Q1 FY'.substr($fiscalYear, -2), $firstFiscalQuarter->getName());
-        $this->assertEquals('Q2 FY'.substr($fiscalYear, -2), $secondFiscalQuarter->getName());
-        $this->assertEquals('Q3 FY'.substr($fiscalYear, -2), $thirdFiscalQuarter->getName());
-        $this->assertEquals('Q4 FY'.substr($fiscalYear, -2), $fourthFiscalQuarter->getName());
+        $this->assertEquals('Q1 FY' . substr($fiscalYear, -2), $firstFiscalQuarter->getName());
+        $this->assertEquals('Q2 FY' . substr($fiscalYear, -2), $secondFiscalQuarter->getName());
+        $this->assertEquals('Q3 FY' . substr($fiscalYear, -2), $thirdFiscalQuarter->getName());
+        $this->assertEquals('Q4 FY' . substr($fiscalYear, -2), $fourthFiscalQuarter->getName());
     }
 
     public function test_current_quarter_names(): void
@@ -181,17 +193,17 @@ class QuarterTest extends TestCase
 
         // Determine expected quarter names based on the current date
         $expectedCalendarQuarter = match (CarbonImmutable::today()->quarter) {
-            1 => 'Q1 CY'.substr($calendarYear, -2),
-            2 => 'Q2 CY'.substr($calendarYear, -2),
-            3 => 'Q3 CY'.substr($calendarYear, -2),
-            4 => 'Q4 CY'.substr($calendarYear, -2),
+            1 => 'Q1 CY' . substr($calendarYear, -2),
+            2 => 'Q2 CY' . substr($calendarYear, -2),
+            3 => 'Q3 CY' . substr($calendarYear, -2),
+            4 => 'Q4 CY' . substr($calendarYear, -2),
         };
 
         $expectedFiscalQuarter = match (CarbonImmutable::today()->quarter) {
-            1 => 'Q3 FY'.substr($fiscalYear - 1, -2),
-            2 => 'Q4 FY'.substr($fiscalYear - 1, -2),
-            3 => 'Q1 FY'.substr($fiscalYear - 1, -2),
-            4 => 'Q2 FY'.substr($fiscalYear - 1, -2),
+            1 => 'Q3 FY' . substr($fiscalYear - 1, -2),
+            2 => 'Q4 FY' . substr($fiscalYear - 1, -2),
+            3 => 'Q1 FY' . substr($fiscalYear - 1, -2),
+            4 => 'Q2 FY' . substr($fiscalYear - 1, -2),
         };
 
         // dd($expectedCalendarQuarter, $expectedFiscalQuarter);


### PR DESCRIPTION
Updated the `previous()` method to accept an optional integer argument that then returns the previous quarter from n quarters ago. So if we are in Q4, and we say `$quarter->previous(2)` it will return the quarter object for Q2. 